### PR TITLE
Bugfix

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -18,7 +18,7 @@ export const getRefresh = async () => {
 
 export const forgetPassword = async (email: string) => {
   const res = await axiosPostRequest("/auth/forgetPassword", { email });
-  if (!res) return;
+  if (!res) return  ;
   successPopup(res.message || "OTP sent to your email");
 };
 

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -7,6 +7,7 @@ interface IPaginationProps {
   totalPages: number;
   previousPage: () => void;
   nextPage: () => void;
+  loading: boolean;
 }
 
 const Pagination: FC<IPaginationProps> = ({
@@ -14,7 +15,12 @@ const Pagination: FC<IPaginationProps> = ({
   totalPages,
   previousPage,
   nextPage,
+  loading,
 }) => {
+  if (loading) {
+    return null;
+  }
+
   if (totalPages <= 0) {
     return (
       <h1 className="text-3xl md:text-4xl font-bold text-center text-gray-400 mt-20">

--- a/src/components/trainer/course/TrainerCourseLiveSession.tsx
+++ b/src/components/trainer/course/TrainerCourseLiveSession.tsx
@@ -322,6 +322,7 @@ const LiveSessionModal: FC<ILiveSessionModalProps> = ({
             <Input
               type="date"
               {...register("date")}
+              min={new Date().toISOString().split("T")[0]}
               className="bg-[#141926] border-white/10 text-white"
             />
             {errors.date?.message && <ErrorText error={errors.date.message} />}

--- a/src/features/user/slice/enrolledCourseSlice.ts
+++ b/src/features/user/slice/enrolledCourseSlice.ts
@@ -16,12 +16,14 @@ interface IInitialState {
   enrolledCourses: Array<IEnrolledCourse>;
   currentPage: number;
   totalPages: number;
+  loading: boolean;
 }
 
 const initialState: IInitialState = {
   enrolledCourses: [],
   currentPage: 0,
   totalPages: 0,
+  loading: false,
 };
 
 const enrolledCoursesSlice = createSlice({
@@ -33,6 +35,14 @@ const enrolledCoursesSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
+    builder.addCase(getEnrolledCoursesApi.pending, (state) => {
+      state.loading = true;
+    });
+
+    builder.addCase(getEnrolledCoursesApi.rejected, (state) => {
+      state.loading = false;
+    });
+
     builder.addCase(getEnrolledCoursesApi.fulfilled, (state, action) => {
       const data: IInitialState = action.payload.data;
       if (data.currentPage == 1) {
@@ -45,6 +55,7 @@ const enrolledCoursesSlice = createSlice({
       }
       state.currentPage = data.currentPage;
       state.totalPages = data.totalPages;
+      state.loading = false;
     });
   },
 });

--- a/src/hooks/useChat.tsx
+++ b/src/hooks/useChat.tsx
@@ -28,13 +28,13 @@ const useChat = () => {
   const reactionHandlerRef =
     useRef<(msgId: string, reactions: IChatMessageReaction[]) => void>(null);
 
-  useEffect(() => {
-    const fetchChat = async () => {
-      const res = await axiosGetRequest("/chats");
-      if (!res) return;
-      setChats(res.data);
-    };
+  const fetchChat = async () => {
+    const res = await axiosGetRequest("/chats");
+    if (!res) return;
+    setChats(res.data);
+  };
 
+  useEffect(() => {
     const fetchTrainers = async () => {
       const res = await axiosGetRequest(`/trainers`);
       if (!res) return;
@@ -62,8 +62,13 @@ const useChat = () => {
         chatId: string;
         lastMessageTime: string;
       }) => {
+        const chat = chats.find((chat) => chat._id === chatId);
+
+        if (!chat) {
+          fetchChat();
+        }
+
         setChats((prevChats) => {
-          const chat = prevChats.find((chat) => chat._id === chatId);
           if (!chat) return prevChats;
 
           const updatedChat = {

--- a/src/hooks/useViewCourseAssignments.tsx
+++ b/src/hooks/useViewCourseAssignments.tsx
@@ -13,6 +13,19 @@ const useCourseAssignments = () => {
   const [assignments, setAssignments] = useState<IAssignmentSubmission[]>([]);
   const { courseId } = useParams();
   const [loading, setLoading] = useState<boolean>(false);
+  const [selectedAssignment, setSelectedAssignment] =
+    useState<IAssignmentSubmission | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModal = (assignment: IAssignmentSubmission) => {
+    setSelectedAssignment(assignment);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setSelectedAssignment(null);
+    setIsModalOpen(false);
+  };
 
   useEffect(() => {
     const fetchAssignments = async () => {
@@ -65,13 +78,32 @@ const useCourseAssignments = () => {
 
     if (!res) return;
     successPopup(res.message || "updated");
-
-    // Update state with new assignment
-    setAssignments((assignments) =>
+    console.log(
+      res.data,
+      assignments,
       assignments.map((assignment) =>
         assignment._id === res.data._id ? res.data : assignment
       )
     );
+    // Update state with new assignment
+    setAssignments((assignments) => {
+      const { status, type, path, content, assignmentId, _id } = res.data;
+      return assignments.map((assignment) => {
+        console.log(assignment);
+        return assignment._id === assignmentId
+          ? {
+              ...assignment,
+              status,
+              type,
+              path,
+              content,
+              assignmentSubmissionId: _id,
+            }
+          : assignment;
+      });
+    });
+
+    closeModal();
   };
 
   const redoAssignment = async (
@@ -114,11 +146,22 @@ const useCourseAssignments = () => {
     successPopup(res.message || "updated");
 
     // Update state with new assignment
-    setAssignments((assignments) =>
-      assignments.map((assignment) =>
-        assignment._id === res.data._id ? res.data : assignment
-      )
-    );
+    setAssignments((assignments) => {
+      const { status, type, path, content, assignmentId, _id } = res.data;
+      return assignments.map((assignment) => {
+        console.log(assignment);
+        return assignment._id === assignmentId
+          ? {
+              ...assignment,
+              status,
+              type,
+              path,
+              content,
+              assignmentSubmissionId: _id,
+            }
+          : assignment;
+      });
+    });
   };
 
   // const redoAssignment = async (
@@ -145,7 +188,17 @@ const useCourseAssignments = () => {
   //   );
   // };
 
-  return { assignments, completeAssignment, redoAssignment, loading };
+  return {
+    assignments,
+    completeAssignment,
+    redoAssignment,
+    loading,
+    selectedAssignment,
+    setSelectedAssignment,
+    openModal,
+    closeModal,
+    isModalOpen,
+  };
 };
 
 export default useCourseAssignments;

--- a/src/pages/Admin/AdminCategoriesPage.tsx
+++ b/src/pages/Admin/AdminCategoriesPage.tsx
@@ -142,6 +142,7 @@ const Categories: FC = () => {
         totalPages={totalPages}
         previousPage={previousPage}
         nextPage={nextPage}
+        loading={loading}
       />
     </AdminLayout>
   );

--- a/src/pages/Admin/AdminCoursesPage.tsx
+++ b/src/pages/Admin/AdminCoursesPage.tsx
@@ -179,6 +179,7 @@ const Courses: FC = () => {
         totalPages={totalPages}
         previousPage={previousPage}
         nextPage={nextPage}
+        loading={loading}
       />
     </AdminLayout>
   );

--- a/src/pages/Admin/AdminQuizSubmissions.tsx
+++ b/src/pages/Admin/AdminQuizSubmissions.tsx
@@ -97,6 +97,7 @@ const AdminQuizSubmissions = () => {
       </Table>
 
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Admin/AdminQuizzesPage.tsx
+++ b/src/pages/Admin/AdminQuizzesPage.tsx
@@ -136,6 +136,7 @@ const AdminQuizzesPage = () => {
       </Table>
 
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Admin/AdminRevenuePage.tsx
+++ b/src/pages/Admin/AdminRevenuePage.tsx
@@ -125,6 +125,7 @@ const AdminRevenue = () => {
       </Table>
 
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Admin/AdminSubscribedUsersPage.tsx
+++ b/src/pages/Admin/AdminSubscribedUsersPage.tsx
@@ -149,6 +149,7 @@ const AdminSubscribedUsersPage = () => {
       </Table>
 
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Admin/AdminSubscriptionPlansPage.tsx
+++ b/src/pages/Admin/AdminSubscriptionPlansPage.tsx
@@ -172,6 +172,7 @@ const AdminSubscriptionPlansPage: FC = () => {
       </Table>
 
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Admin/AdminTopicsPage.tsx
+++ b/src/pages/Admin/AdminTopicsPage.tsx
@@ -112,6 +112,7 @@ const AdminTopicsPage = () => {
       </Table>
 
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Admin/AdminTrainerRequestsPage.tsx
+++ b/src/pages/Admin/AdminTrainerRequestsPage.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { useSelector, useDispatch } from "react-redux";
 
-import {AdminLayout} from "@/layouts";
+import { AdminLayout } from "@/layouts";
 import {
   AiOutlineCheckCircle,
   AiFillCloseCircle,
@@ -15,7 +15,7 @@ import {
   TableHeader,
   TableRow,
   Pagination,
-  TableSkeleton
+  TableSkeleton,
 } from "@/components";
 import { AppDispatch, RootReducer } from "@/store";
 import { changePage } from "@/features/admin/slice/adminTrainerRequestSlice";
@@ -140,6 +140,7 @@ const TrainerRequest: FC = () => {
         totalPages={totalPages}
         previousPage={previousPage}
         nextPage={nextPage}
+        loading={loading}
       />
     </AdminLayout>
   );

--- a/src/pages/Admin/AdminTransactions.tsx
+++ b/src/pages/Admin/AdminTransactions.tsx
@@ -174,6 +174,7 @@ const Transactions: FC = () => {
         )}
       </Table>
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Admin/AdminUsers.tsx
+++ b/src/pages/Admin/AdminUsers.tsx
@@ -123,6 +123,7 @@ const Users: FC = () => {
       </Table>
 
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Admin/AdminUsers.tsx
+++ b/src/pages/Admin/AdminUsers.tsx
@@ -50,7 +50,7 @@ const Users: FC = () => {
 
   const blockUnblockUser = (userId: string, blocked: boolean) => {
     confirm(
-      `Are you sure you want to ${blocked ? "block" : "unblock"} this user?`,
+      `Are you sure you want to ${blocked ? "unblock" : "block"} this user?`,
       () => {
         dispatch(adminBlockUnblockUserApi(userId));
       }

--- a/src/pages/Auth/LoginRegisterPage.tsx
+++ b/src/pages/Auth/LoginRegisterPage.tsx
@@ -52,7 +52,7 @@ const LoginRegisterPage: FC = () => {
 
   return (
     <AuthLayout>
-      <div className="sm:bg-app-border w-full sm:w-[500px] lg:w-[1100px] h-[600px] flex ">
+      <div className="sm:bg-app-border w-full sm:w-[500px] lg:w-[1100px] h-[560px] flex ">
         <div className="hidden w-1/2 h-full lg:block">
           <img src={LoginImage} alt="" className="object-cover h-full" />
         </div>

--- a/src/pages/Trainer/TrainerAssignmentSubmissionsPage.tsx
+++ b/src/pages/Trainer/TrainerAssignmentSubmissionsPage.tsx
@@ -39,9 +39,8 @@ const getStatusBadgeClass = (status: string) => {
 
 const TrainerAssignmentSubmissions = () => {
   const dispatch: AppDispatch = useDispatch();
-  const { assignmentSubmissions, currentPage, totalPages } = useSelector(
-    (state: RootReducer) => state.trainerAssignmentSubmissions
-  );
+  const { assignmentSubmissions, currentPage, totalPages, loading } =
+    useSelector((state: RootReducer) => state.trainerAssignmentSubmissions);
 
   const { nextPage, paginatedData, previousPage, refreshHandler } =
     usePaginatedData({
@@ -141,6 +140,7 @@ const TrainerAssignmentSubmissions = () => {
         />
       )}
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Trainer/TrainerCoursesPage.tsx
+++ b/src/pages/Trainer/TrainerCoursesPage.tsx
@@ -121,6 +121,7 @@ const MyCourses: FC = () => {
       </Table>
 
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Trainer/TrainerRevenuePage.tsx
+++ b/src/pages/Trainer/TrainerRevenuePage.tsx
@@ -123,6 +123,7 @@ const TrainerRevenue = () => {
       </Table>
 
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/Trainer/TrainerStudentsPage.tsx
+++ b/src/pages/Trainer/TrainerStudentsPage.tsx
@@ -78,6 +78,7 @@ const Students: FC = () => {
       </Table>
 
       <Pagination
+        loading={loading}
         currentPage={currentPage}
         totalPages={totalPages}
         previousPage={previousPage}

--- a/src/pages/User/UserEnrolledCourseAssignmentsPage.tsx
+++ b/src/pages/User/UserEnrolledCourseAssignmentsPage.tsx
@@ -7,10 +7,8 @@ import {
   ShieldCheck,
   Eye,
 } from "lucide-react";
-import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { useCourseAssignments } from "@/hooks";
-import { IAssignmentSubmission } from "@/types/courseType";
 import { AssignmentModal, DivLoading } from "@/components";
 
 const statusConfig = {
@@ -53,21 +51,16 @@ const statusConfig = {
 };
 
 const UserCourseAssignmentsPage = () => {
-  const { assignments, completeAssignment, redoAssignment, loading } =
-    useCourseAssignments();
-  const [selectedAssignment, setSelectedAssignment] =
-    useState<IAssignmentSubmission | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const openModal = (assignment: IAssignmentSubmission) => {
-    setSelectedAssignment(assignment);
-    setIsModalOpen(true);
-  };
-
-  const closeModal = () => {
-    setSelectedAssignment(null);
-    setIsModalOpen(false);
-  };
+  const {
+    assignments,
+    completeAssignment,
+    redoAssignment,
+    loading,
+    closeModal,
+    isModalOpen,
+    openModal,
+    selectedAssignment,
+  } = useCourseAssignments();
 
   const groupedAssignments = {
     pending: assignments.filter((a) => a.status === "pending"),

--- a/src/pages/User/UserEnrolledCoursesPage.tsx
+++ b/src/pages/User/UserEnrolledCoursesPage.tsx
@@ -11,7 +11,7 @@ import { RootReducer } from "@/store";
 const PAGE_SIZE = 6;
 
 const EnrolledCourse: FC = () => {
-  const { enrolledCourses, currentPage, totalPages } = useSelector(
+  const { enrolledCourses, currentPage, totalPages, loading } = useSelector(
     (state: RootReducer) => state.enrolledCourses
   );
 
@@ -48,6 +48,7 @@ const EnrolledCourse: FC = () => {
 
           {paginatedData.length != 0 ? (
             <Pagination
+              loading={loading}
               currentPage={currentPage}
               totalPages={totalPages}
               previousPage={previousPage}

--- a/src/pages/User/UserProfilePage.tsx
+++ b/src/pages/User/UserProfilePage.tsx
@@ -570,8 +570,7 @@ const EditExperience = () => {
               type="button"
               onClick={() => setShowAddForm(false)}
               size="sm"
-              variant="outline"
-              className="text-white border-white/20 hover:bg-white/10 transition-all duration-300"
+              className="text-white bg-red-600 hover:bg-red-700 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
             >
               Cancel
             </Button>

--- a/src/pages/User/UserQuizzesPage.tsx
+++ b/src/pages/User/UserQuizzesPage.tsx
@@ -126,6 +126,7 @@ const UserQuizzesPage = () => {
           )}
 
           <Pagination
+            loading={loading}
             currentPage={currentPage}
             totalPages={totalPages}
             previousPage={previousPage}

--- a/src/pages/User/UserTrainerRequestPage.tsx
+++ b/src/pages/User/UserTrainerRequestPage.tsx
@@ -43,12 +43,14 @@ const TrainerRequest: FC = () => {
     const res = await axiosPostRequest(TRAINER_REQUEST_API, {});
     if (!res) return;
     successPopup(res.message || "Trainer request sent");
+    setRequestStatus({ status: "pending" });
   };
 
   const resendTrainerRequest = async () => {
     const res = await axiosPutRequest(TRAINER_REQUEST_API, {});
     if (!res) return;
     successPopup(res.message || "Trainer request sent");
+    setRequestStatus({ status: "pending" });
   };
 
   useEffect(() => {
@@ -124,7 +126,7 @@ const TrainerRequest: FC = () => {
           </>
         );
       }
-    } 
+    }
 
     return (
       <>

--- a/src/pages/User/UserTransactionsPage.tsx
+++ b/src/pages/User/UserTransactionsPage.tsx
@@ -198,6 +198,7 @@ const Transactions: FC = () => {
             )}
           </Table>
           <Pagination
+            loading={loading}
             currentPage={currentPage}
             totalPages={totalPages}
             previousPage={previousPage}

--- a/src/pages/User/UserWalletHistoryPage.tsx
+++ b/src/pages/User/UserWalletHistoryPage.tsx
@@ -81,6 +81,7 @@ const UserWalletHistoryPage = () => {
             )}
           </Table>
           <Pagination
+            loading={loading}
             currentPage={currentPage}
             totalPages={totalPages}
             previousPage={previousPage}

--- a/src/pages/public/CoursesPage.tsx
+++ b/src/pages/public/CoursesPage.tsx
@@ -164,6 +164,7 @@ const Courses: FC = () => {
 
       {!!paginatedData.length && (
         <Pagination
+          loading={loading}
           currentPage={currentPage}
           totalPages={totalPages}
           previousPage={previousPage}


### PR DESCRIPTION
## Summary
- Fixed multiple trainer requests being sent from the UI.  
- Prevented duplicate assignment submissions when the modal is not closed.  
- Added frontend validation to block scheduling live sessions with past dates.  
- Fixed chat list not updating on the trainer side until page refresh.  

## Changes
- Disabled "Send Trainer Request" button after first submission.  
- Reset/close assignment modal after successful submission to avoid duplicate triggers.  
- Added date validation in live session scheduling form to disallow past dates.  
- Updated chat state management to auto-refresh trainer chat list when a new conversation is started.  

## Impact
- Users can only send one trainer request per account.  
- Assignment submissions are no longer duplicated by UI behavior.  
- Live sessions can only be scheduled for valid future times.  
- Trainers see new user chats without needing a manual refresh.  
